### PR TITLE
Note that lean-data-science version is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ kc.get_credential("my_secret")
 
 Install the **JupyterLab Credential Store**:
 
+*NOTE - the below @lean-data-science image is not compatible with recent Jupyter versions*
+
 ```bash
 pip install pycrypto
 apt-get install nodejs -y


### PR DESCRIPTION
The Lean Data Science version hosted on https://www.npmjs.com/ is no longer compatible with recent Jupyter versions. https://www.npmjs.com/package/@ccorbin/credentialstore is... Perhaps adding this one there would be nice as well.